### PR TITLE
Add pools ordering

### DIFF
--- a/api-tests/src/graphql-queries.js
+++ b/api-tests/src/graphql-queries.js
@@ -626,15 +626,15 @@ export async function createSetPool(poolName, resourceTypeId, poolValues){
     .catch(error => console.log(error));
 }
 
-export async function createAllocationPool(poolName, resourceTypeId, strategyId, poolPropertyTypes, poolProperties, tags = null, suppressErrors = false){
+export async function createAllocationPool(poolName, resourceTypeId, strategyId, poolPropertyTypes, poolProperties, tags = null, suppressErrors = false, dealocationSafetyPeriod = 0){
     return client.mutate({
         mutation: gql`
-            mutation createAllocPool($poolName: String!, $resourceTypeId: ID!, $strategyId: ID!, $poolProperties: Map!, $poolPropertyTypes: Map!, $tags: [String!]) {
+            mutation createAllocPool($poolName: String!, $resourceTypeId: ID!, $strategyId: ID!, $poolProperties: Map!, $poolPropertyTypes: Map!, $tags: [String!], $dealocationSafetyPeriod: Int!) {
                 CreateAllocatingPool( input:  {
                     resourceTypeId: $resourceTypeId
                     poolName: $poolName
                     allocationStrategyId: $strategyId
-                    poolDealocationSafetyPeriod: 0
+                    poolDealocationSafetyPeriod: $dealocationSafetyPeriod
                     poolPropertyTypes: $poolPropertyTypes
                     poolProperties: $poolProperties
                     tags: $tags
@@ -653,6 +653,7 @@ export async function createAllocationPool(poolName, resourceTypeId, strategyId,
             strategyId: strategyId,
             poolProperties: poolProperties,
             poolPropertyTypes: poolPropertyTypes,
+            dealocationSafetyPeriod: dealocationSafetyPeriod,
             tags: tags,
         }
     })
@@ -988,11 +989,11 @@ export async function getRequiredPoolProperties(allocationStrategyName) {
     .catch(error => console.log(error));
 }
 
-export async function queryResourcePools(first, last, before, after, filter){
+export async function queryResourcePools(first, last, before, after, filter, sortBy){
     return client.query({
         query: gql`
-            query getResourcePools($first: Int, $last: Int, $before: Cursor, $after: Cursor, $filter: Map) {
-                QueryResourcePools(first: $first, last: $last, before: $before, after: $after, filterByResources: $filter) {
+            query getResourcePools($first: Int, $last: Int, $before: Cursor, $after: Cursor, $filter: Map, $sortBy: SortResourcePoolsInput) {
+                QueryResourcePools(first: $first, last: $last, before: $before, after: $after, filterByResources: $filter, sortBy: $sortBy) {
                     edges {
                         node {
                             id
@@ -1004,6 +1005,8 @@ export async function queryResourcePools(first, last, before, after, filter){
                                     }
                                 }
                             }
+                            Name
+                            DealocationSafetyPeriod
                         }
                         cursor{
                             ID
@@ -1028,7 +1031,8 @@ export async function queryResourcePools(first, last, before, after, filter){
             last: last,
             before: before,
             after: after,
-            filter: filter
+            filter: filter,
+            sortBy: sortBy
         }
     })
     .then(result => result.data.QueryResourcePools)

--- a/api-tests/src/test-helpers.js
+++ b/api-tests/src/test-helpers.js
@@ -115,11 +115,26 @@ export async function createIpv6NestedPool(parentResourceId) {
         parentResourceId);
 }
 
-export async function createIpv4PrefixRootPool(address = "10.0.0.0", prefix = 8, subnet = false) {
+export async function createIpv4PrefixRootPool(address = "10.0.0.0", prefix = 8, subnet = false, dealocationSafetyPeriod = 0) {
     let resourceTypeId = await findResourceTypeId('ipv4_prefix');
     let strategyId = await findAllocationStrategyId('ipv4_prefix');
     return await createAllocationPool(
         getUniqueName('ipv4-root'),
+        resourceTypeId,
+        strategyId,
+        {prefix: "int", address: "string", subnet: "bool"},
+        {prefix: prefix, address: address, subnet: subnet},
+        null,
+        false,
+        dealocationSafetyPeriod
+    );
+}
+
+export async function createIpv4PrefixRootPoolWithName(name, address = "10.0.0.0", prefix = 8, subnet = false) {
+    let resourceTypeId = await findResourceTypeId('ipv4_prefix');
+    let strategyId = await findAllocationStrategyId('ipv4_prefix');
+    return await createAllocationPool(
+        getUniqueName(name),
         resourceTypeId,
         strategyId,
         {prefix: "int", address: "string", subnet: "bool"},

--- a/api-tests/src/tests/pool.test.js
+++ b/api-tests/src/tests/pool.test.js
@@ -24,7 +24,7 @@ import {
 } from "../graphql-queries.js";
 import {
     cleanup,
-    createIpv4PrefixRootPool,
+    createIpv4PrefixRootPool, createIpv4PrefixRootPoolWithName,
     createIpv4RootPool,
     createIpv6PrefixRootPool,
     createIpv6RootPool, createRandomIntRootPool, createRdRootPool,
@@ -636,6 +636,73 @@ test('test filtering by allocated resource properties', async (t) => {
     t.equal(byIpv6Addr.edges.length, 1);
     t.equal(byIpv6Addr2.edges.length, 1);
     t.equal(byIpv4Addr.edges.length, 1);
+
+    await cleanup();
+    t.end();
+});
+
+test('test ordering of resource pools by name in descending direction', async (t) => {
+    for (let i = 0; i < 3; i++) {
+        await createIpv4PrefixRootPoolWithName(`pool-${i}`);
+    }
+
+    const pools = await queryResourcePools(undefined, undefined, undefined, undefined, undefined, {
+        sortKey: "name",
+        direction: "desc"
+    });
+
+    t.equal(pools.edges[0].node.Name.substring(0, 6), "pool-2");
+
+    await cleanup();
+    t.end();
+});
+
+test('test ordering of resource pools by name in ascending direction', async (t) => {
+    for (let i = 0; i < 3; i++) {
+        await createIpv4PrefixRootPoolWithName(`pool-${i}`);
+    }
+
+    const pools = await queryResourcePools(undefined, undefined, undefined, undefined, undefined, {
+        sortKey: "name",
+        direction: "asc"
+    });
+
+    t.equal(pools.edges[0].node.Name.substring(0, 6), "pool-0");
+
+    await cleanup();
+    t.end();
+});
+
+test('test ordering of resource pools by dealocation safety period in descending direction', async (t) => {
+    for (let i = 0; i < 3; i++) {
+        await createIpv4PrefixRootPool("10.0.0.0", 24, false, i);
+    }
+
+    const pools = await queryResourcePools(undefined, undefined, undefined, undefined, undefined, {
+        sortKey: "dealocationSafetyPeriod",
+        direction: "desc"
+    });
+
+    console.log(pools.edges.map((pool) => pool.node.DealocationSafetyPeriod));
+    t.equal(pools.edges[0].node.DealocationSafetyPeriod, 2);
+
+    await cleanup();
+    t.end();
+});
+
+test('test ordering of resource pools by dealocation safety period in ascending direction', async (t) => {
+    for (let i = 0; i < 3; i++) {
+        await createIpv4PrefixRootPool("10.0.0.0", 24, false, i);
+    }
+
+    const pools = await queryResourcePools(undefined, undefined, undefined, undefined, undefined, {
+        sortKey: "dealocationSafetyPeriod",
+        direction: "asc"
+    });
+
+    console.log(pools.edges.map((pool) => pool.node.DealocationSafetyPeriod));
+
+    t.equal(pools.edges[0].node.DealocationSafetyPeriod, 0);
 
     await cleanup();
     t.end();

--- a/api-tests/src/tests/pool.test.js
+++ b/api-tests/src/tests/pool.test.js
@@ -683,7 +683,6 @@ test('test ordering of resource pools by dealocation safety period in descending
         direction: "desc"
     });
 
-    console.log(pools.edges.map((pool) => pool.node.DealocationSafetyPeriod));
     t.equal(pools.edges[0].node.DealocationSafetyPeriod, 2);
 
     await cleanup();
@@ -700,9 +699,24 @@ test('test ordering of resource pools by dealocation safety period in ascending 
         direction: "asc"
     });
 
-    console.log(pools.edges.map((pool) => pool.node.DealocationSafetyPeriod));
-
     t.equal(pools.edges[0].node.DealocationSafetyPeriod, 0);
+
+    await cleanup();
+    t.end();
+});
+
+test('test ordering of resource pools by dealocation safety period in ascending direction', async (t) => {
+    for (let i = 0; i < 3; i++) {
+        await createIpv4PrefixRootPool("10.0.0.0", 24, false, i);
+    }
+
+    const pools = await queryResourcePools(undefined, undefined, undefined, undefined, undefined, {
+        sortKey: "nonExistingSortKey",
+        direction: "asc"
+    });
+
+
+    t.notOk(pools);
 
     await cleanup();
     t.end();

--- a/graph/graphql/generated/generated.go
+++ b/graph/graphql/generated/generated.go
@@ -205,17 +205,18 @@ type ComplexityRoot struct {
 	}
 
 	ResourcePool struct {
-		AllocatedResources func(childComplexity int, first *int, last *int, before *string, after *string) int
-		AllocationStrategy func(childComplexity int) int
-		Capacity           func(childComplexity int) int
-		ID                 func(childComplexity int) int
-		Name               func(childComplexity int) int
-		ParentResource     func(childComplexity int) int
-		PoolProperties     func(childComplexity int) int
-		PoolType           func(childComplexity int) int
-		ResourceType       func(childComplexity int) int
-		Resources          func(childComplexity int) int
-		Tags               func(childComplexity int) int
+		AllocatedResources      func(childComplexity int, first *int, last *int, before *string, after *string) int
+		AllocationStrategy      func(childComplexity int) int
+		Capacity                func(childComplexity int) int
+		DealocationSafetyPeriod func(childComplexity int) int
+		ID                      func(childComplexity int) int
+		Name                    func(childComplexity int) int
+		ParentResource          func(childComplexity int) int
+		PoolProperties          func(childComplexity int) int
+		PoolType                func(childComplexity int) int
+		ResourceType            func(childComplexity int) int
+		Resources               func(childComplexity int) int
+		Tags                    func(childComplexity int) int
 	}
 
 	ResourcePoolConnection struct {
@@ -1149,6 +1150,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.ResourcePool.Capacity(childComplexity), true
 
+	case "ResourcePool.DealocationSafetyPeriod":
+		if e.complexity.ResourcePool.DealocationSafetyPeriod == nil {
+			break
+		}
+
+		return e.complexity.ResourcePool.DealocationSafetyPeriod(childComplexity), true
+
 	case "ResourcePool.id":
 		if e.complexity.ResourcePool.ID == nil {
 			break
@@ -1503,6 +1511,7 @@ type ResourcePool implements Node
     PoolType: PoolType!
     ResourceType: ResourceType!
     Resources: [Resource!]!
+    DealocationSafetyPeriod: Int!
     Tags: [Tag!]!
     allocatedResources(first: Int, last: Int, before: String, after: String): ResourceConnection
     id: ID!
@@ -1764,7 +1773,7 @@ type PoolCapacityPayload {
 
 enum SortResourcePoolsBy {
     name
-    deallocationSafetyPeriod
+    dealocationSafetyPeriod
 }
 
 enum SortDirection {
@@ -3459,6 +3468,8 @@ func (ec *executionContext) fieldContext_CreateAllocatingPoolPayload_pool(ctx co
 				return ec.fieldContext_ResourcePool_ResourceType(ctx, field)
 			case "Resources":
 				return ec.fieldContext_ResourcePool_Resources(ctx, field)
+			case "DealocationSafetyPeriod":
+				return ec.fieldContext_ResourcePool_DealocationSafetyPeriod(ctx, field)
 			case "Tags":
 				return ec.fieldContext_ResourcePool_Tags(ctx, field)
 			case "allocatedResources":
@@ -3577,6 +3588,8 @@ func (ec *executionContext) fieldContext_CreateNestedAllocatingPoolPayload_pool(
 				return ec.fieldContext_ResourcePool_ResourceType(ctx, field)
 			case "Resources":
 				return ec.fieldContext_ResourcePool_Resources(ctx, field)
+			case "DealocationSafetyPeriod":
+				return ec.fieldContext_ResourcePool_DealocationSafetyPeriod(ctx, field)
 			case "Tags":
 				return ec.fieldContext_ResourcePool_Tags(ctx, field)
 			case "allocatedResources":
@@ -3642,6 +3655,8 @@ func (ec *executionContext) fieldContext_CreateNestedSetPoolPayload_pool(ctx con
 				return ec.fieldContext_ResourcePool_ResourceType(ctx, field)
 			case "Resources":
 				return ec.fieldContext_ResourcePool_Resources(ctx, field)
+			case "DealocationSafetyPeriod":
+				return ec.fieldContext_ResourcePool_DealocationSafetyPeriod(ctx, field)
 			case "Tags":
 				return ec.fieldContext_ResourcePool_Tags(ctx, field)
 			case "allocatedResources":
@@ -3707,6 +3722,8 @@ func (ec *executionContext) fieldContext_CreateNestedSingletonPoolPayload_pool(c
 				return ec.fieldContext_ResourcePool_ResourceType(ctx, field)
 			case "Resources":
 				return ec.fieldContext_ResourcePool_Resources(ctx, field)
+			case "DealocationSafetyPeriod":
+				return ec.fieldContext_ResourcePool_DealocationSafetyPeriod(ctx, field)
 			case "Tags":
 				return ec.fieldContext_ResourcePool_Tags(ctx, field)
 			case "allocatedResources":
@@ -3826,6 +3843,8 @@ func (ec *executionContext) fieldContext_CreateSetPoolPayload_pool(ctx context.C
 				return ec.fieldContext_ResourcePool_ResourceType(ctx, field)
 			case "Resources":
 				return ec.fieldContext_ResourcePool_Resources(ctx, field)
+			case "DealocationSafetyPeriod":
+				return ec.fieldContext_ResourcePool_DealocationSafetyPeriod(ctx, field)
 			case "Tags":
 				return ec.fieldContext_ResourcePool_Tags(ctx, field)
 			case "allocatedResources":
@@ -3891,6 +3910,8 @@ func (ec *executionContext) fieldContext_CreateSingletonPoolPayload_pool(ctx con
 				return ec.fieldContext_ResourcePool_ResourceType(ctx, field)
 			case "Resources":
 				return ec.fieldContext_ResourcePool_Resources(ctx, field)
+			case "DealocationSafetyPeriod":
+				return ec.fieldContext_ResourcePool_DealocationSafetyPeriod(ctx, field)
 			case "Tags":
 				return ec.fieldContext_ResourcePool_Tags(ctx, field)
 			case "allocatedResources":
@@ -6689,6 +6710,8 @@ func (ec *executionContext) fieldContext_Query_QueryResourcePool(ctx context.Con
 				return ec.fieldContext_ResourcePool_ResourceType(ctx, field)
 			case "Resources":
 				return ec.fieldContext_ResourcePool_Resources(ctx, field)
+			case "DealocationSafetyPeriod":
+				return ec.fieldContext_ResourcePool_DealocationSafetyPeriod(ctx, field)
 			case "Tags":
 				return ec.fieldContext_ResourcePool_Tags(ctx, field)
 			case "allocatedResources":
@@ -6957,6 +6980,8 @@ func (ec *executionContext) fieldContext_Query_QueryResourcePoolHierarchyPath(ct
 				return ec.fieldContext_ResourcePool_ResourceType(ctx, field)
 			case "Resources":
 				return ec.fieldContext_ResourcePool_Resources(ctx, field)
+			case "DealocationSafetyPeriod":
+				return ec.fieldContext_ResourcePool_DealocationSafetyPeriod(ctx, field)
 			case "Tags":
 				return ec.fieldContext_ResourcePool_Tags(ctx, field)
 			case "allocatedResources":
@@ -7496,6 +7521,8 @@ func (ec *executionContext) fieldContext_Resource_NestedPool(ctx context.Context
 				return ec.fieldContext_ResourcePool_ResourceType(ctx, field)
 			case "Resources":
 				return ec.fieldContext_ResourcePool_Resources(ctx, field)
+			case "DealocationSafetyPeriod":
+				return ec.fieldContext_ResourcePool_DealocationSafetyPeriod(ctx, field)
 			case "Tags":
 				return ec.fieldContext_ResourcePool_Tags(ctx, field)
 			case "allocatedResources":
@@ -7564,6 +7591,8 @@ func (ec *executionContext) fieldContext_Resource_ParentPool(ctx context.Context
 				return ec.fieldContext_ResourcePool_ResourceType(ctx, field)
 			case "Resources":
 				return ec.fieldContext_ResourcePool_Resources(ctx, field)
+			case "DealocationSafetyPeriod":
+				return ec.fieldContext_ResourcePool_DealocationSafetyPeriod(ctx, field)
 			case "Tags":
 				return ec.fieldContext_ResourcePool_Tags(ctx, field)
 			case "allocatedResources":
@@ -8359,6 +8388,50 @@ func (ec *executionContext) fieldContext_ResourcePool_Resources(ctx context.Cont
 	return fc, nil
 }
 
+func (ec *executionContext) _ResourcePool_DealocationSafetyPeriod(ctx context.Context, field graphql.CollectedField, obj *ent.ResourcePool) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ResourcePool_DealocationSafetyPeriod(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.DealocationSafetyPeriod, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(int)
+	fc.Result = res
+	return ec.marshalNInt2int(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ResourcePool_DealocationSafetyPeriod(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ResourcePool",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _ResourcePool_Tags(ctx context.Context, field graphql.CollectedField, obj *ent.ResourcePool) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_ResourcePool_Tags(ctx, field)
 	if err != nil {
@@ -8766,6 +8839,8 @@ func (ec *executionContext) fieldContext_ResourcePoolEdge_node(ctx context.Conte
 				return ec.fieldContext_ResourcePool_ResourceType(ctx, field)
 			case "Resources":
 				return ec.fieldContext_ResourcePool_Resources(ctx, field)
+			case "DealocationSafetyPeriod":
+				return ec.fieldContext_ResourcePool_DealocationSafetyPeriod(ctx, field)
 			case "Tags":
 				return ec.fieldContext_ResourcePool_Tags(ctx, field)
 			case "allocatedResources":
@@ -8878,6 +8953,8 @@ func (ec *executionContext) fieldContext_ResourceType_Pools(ctx context.Context,
 				return ec.fieldContext_ResourcePool_ResourceType(ctx, field)
 			case "Resources":
 				return ec.fieldContext_ResourcePool_Resources(ctx, field)
+			case "DealocationSafetyPeriod":
+				return ec.fieldContext_ResourcePool_DealocationSafetyPeriod(ctx, field)
 			case "Tags":
 				return ec.fieldContext_ResourcePool_Tags(ctx, field)
 			case "allocatedResources":
@@ -9047,6 +9124,8 @@ func (ec *executionContext) fieldContext_Tag_Pools(ctx context.Context, field gr
 				return ec.fieldContext_ResourcePool_ResourceType(ctx, field)
 			case "Resources":
 				return ec.fieldContext_ResourcePool_Resources(ctx, field)
+			case "DealocationSafetyPeriod":
+				return ec.fieldContext_ResourcePool_DealocationSafetyPeriod(ctx, field)
 			case "Tags":
 				return ec.fieldContext_ResourcePool_Tags(ctx, field)
 			case "allocatedResources":
@@ -13753,6 +13832,13 @@ func (ec *executionContext) _ResourcePool(ctx context.Context, sel ast.Selection
 				return innerFunc(ctx)
 
 			})
+		case "DealocationSafetyPeriod":
+
+			out.Values[i] = ec._ResourcePool_DealocationSafetyPeriod(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&invalids, 1)
+			}
 		case "Tags":
 			field := field
 

--- a/graph/graphql/model/models_gen.go
+++ b/graph/graphql/model/models_gen.go
@@ -3,6 +3,10 @@
 package model
 
 import (
+	"fmt"
+	"io"
+	"strconv"
+
 	"github.com/net-auto/resourceManager/ent"
 	"github.com/net-auto/resourceManager/ent/allocationstrategy"
 )
@@ -198,6 +202,11 @@ type ResourcePoolInput struct {
 	PoolProperties   map[string]interface{} `json:"poolProperties"`
 }
 
+type SortResourcePoolsInput struct {
+	SortKey   SortResourcePoolsBy `json:"sortKey"`
+	Direction SortDirection       `json:"direction"`
+}
+
 // Helper entities for tag search
 type TagAnd struct {
 	MatchesAll []string `json:"matchesAll"`
@@ -250,4 +259,86 @@ type UpdateTagInput struct {
 // Output of updating a tag
 type UpdateTagPayload struct {
 	Tag *ent.Tag `json:"tag"`
+}
+
+type SortDirection string
+
+const (
+	SortDirectionAsc  SortDirection = "asc"
+	SortDirectionDesc SortDirection = "desc"
+)
+
+var AllSortDirection = []SortDirection{
+	SortDirectionAsc,
+	SortDirectionDesc,
+}
+
+func (e SortDirection) IsValid() bool {
+	switch e {
+	case SortDirectionAsc, SortDirectionDesc:
+		return true
+	}
+	return false
+}
+
+func (e SortDirection) String() string {
+	return string(e)
+}
+
+func (e *SortDirection) UnmarshalGQL(v interface{}) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = SortDirection(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid SortDirection", str)
+	}
+	return nil
+}
+
+func (e SortDirection) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
+type SortResourcePoolsBy string
+
+const (
+	SortResourcePoolsByName                     SortResourcePoolsBy = "name"
+	SortResourcePoolsByDeallocationSafetyPeriod SortResourcePoolsBy = "deallocationSafetyPeriod"
+)
+
+var AllSortResourcePoolsBy = []SortResourcePoolsBy{
+	SortResourcePoolsByName,
+	SortResourcePoolsByDeallocationSafetyPeriod,
+}
+
+func (e SortResourcePoolsBy) IsValid() bool {
+	switch e {
+	case SortResourcePoolsByName, SortResourcePoolsByDeallocationSafetyPeriod:
+		return true
+	}
+	return false
+}
+
+func (e SortResourcePoolsBy) String() string {
+	return string(e)
+}
+
+func (e *SortResourcePoolsBy) UnmarshalGQL(v interface{}) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = SortResourcePoolsBy(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid SortResourcePoolsBy", str)
+	}
+	return nil
+}
+
+func (e SortResourcePoolsBy) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
 }

--- a/graph/graphql/model/models_gen.go
+++ b/graph/graphql/model/models_gen.go
@@ -305,18 +305,18 @@ func (e SortDirection) MarshalGQL(w io.Writer) {
 type SortResourcePoolsBy string
 
 const (
-	SortResourcePoolsByName                     SortResourcePoolsBy = "name"
-	SortResourcePoolsByDeallocationSafetyPeriod SortResourcePoolsBy = "deallocationSafetyPeriod"
+	SortResourcePoolsByName                    SortResourcePoolsBy = "name"
+	SortResourcePoolsByDealocationSafetyPeriod SortResourcePoolsBy = "dealocationSafetyPeriod"
 )
 
 var AllSortResourcePoolsBy = []SortResourcePoolsBy{
 	SortResourcePoolsByName,
-	SortResourcePoolsByDeallocationSafetyPeriod,
+	SortResourcePoolsByDealocationSafetyPeriod,
 }
 
 func (e SortResourcePoolsBy) IsValid() bool {
 	switch e {
-	case SortResourcePoolsByName, SortResourcePoolsByDeallocationSafetyPeriod:
+	case SortResourcePoolsByName, SortResourcePoolsByDealocationSafetyPeriod:
 		return true
 	}
 	return false

--- a/graph/graphql/resolver/schema.resolvers.go
+++ b/graph/graphql/resolver/schema.resolvers.go
@@ -812,7 +812,14 @@ func (r *queryResolver) QueryEmptyResourcePools(ctx context.Context, resourceTyp
 	}
 
 	if sortBy != nil {
-		query = orderResourcePool(sortBy, query)
+		orderQuery, err := orderResourcePool(sortBy, query)
+
+		if err != nil {
+			log.Error(ctx, err, "Unable to retrieve resource pools")
+			return nil, gqlerror.Errorf("Unable to query resource pools: %v", err)
+		}
+
+		query = orderQuery
 	}
 
 	if resourcePools, err := query.Paginate(ctx, after, first, before, last); err != nil {
@@ -849,7 +856,14 @@ func (r *queryResolver) QueryResourcePools(ctx context.Context, resourceTypeID *
 	}
 
 	if sortBy != nil {
-		query = orderResourcePool(sortBy, query)
+		orderQuery, err := orderResourcePool(sortBy, query)
+
+		if err != nil {
+			log.Error(ctx, err, "Unable to retrieve resource pools")
+			return nil, gqlerror.Errorf("Unable to query resource pools: %v", err)
+		}
+
+		query = orderQuery
 	}
 
 	if resourcePools, err := query.Paginate(ctx, after, first, before, last); err != nil {
@@ -959,7 +973,14 @@ func (r *queryResolver) QueryRootResourcePools(ctx context.Context, resourceType
 	}
 
 	if sortBy != nil {
-		query = orderResourcePool(sortBy, query)
+		orderQuery, err := orderResourcePool(sortBy, query)
+
+		if err != nil {
+			log.Error(ctx, err, "Unable to retrieve resource pools")
+			return nil, gqlerror.Errorf("Unable to query resource pools: %v", err)
+		}
+
+		query = orderQuery
 	}
 
 	if resourcePools, err := query.Paginate(ctx, after, first, before, last); err != nil {
@@ -999,7 +1020,14 @@ func (r *queryResolver) QueryLeafResourcePools(ctx context.Context, resourceType
 	}
 
 	if sortBy != nil {
-		query = orderResourcePool(sortBy, query)
+		orderQuery, err := orderResourcePool(sortBy, query)
+
+		if err != nil {
+			log.Error(ctx, err, "Unable to retrieve resource pools")
+			return nil, gqlerror.Errorf("Unable to query resource pools: %v", err)
+		}
+
+		query = orderQuery
 	}
 
 	if resourcePools, err := query.Paginate(ctx, after, first, before, last); err != nil {

--- a/graph/graphql/resolver/schema.resolvers.go
+++ b/graph/graphql/resolver/schema.resolvers.go
@@ -800,7 +800,7 @@ func (r *queryResolver) QueryResourcePool(ctx context.Context, poolID int) (*ent
 }
 
 // QueryEmptyResourcePools is the resolver for the QueryEmptyResourcePools field.
-func (r *queryResolver) QueryEmptyResourcePools(ctx context.Context, resourceTypeID *int, first *int, last *int, before *ent.Cursor, after *ent.Cursor) (*ent.ResourcePoolConnection, error) {
+func (r *queryResolver) QueryEmptyResourcePools(ctx context.Context, resourceTypeID *int, first *int, last *int, before *ent.Cursor, after *ent.Cursor, sortBy *model.SortResourcePoolsInput) (*ent.ResourcePoolConnection, error) {
 	client := r.ClientFrom(ctx)
 	query := client.ResourcePool.Query()
 
@@ -808,6 +808,10 @@ func (r *queryResolver) QueryEmptyResourcePools(ctx context.Context, resourceTyp
 		query.Where(resourcePool.HasResourceTypeWith(resourcetype.ID(*resourceTypeID))).Where(resourcePool.Not(resourcePool.HasClaims()))
 	} else {
 		query.Where(resourcePool.Not(resourcePool.HasClaims()))
+	}
+
+	if sortBy != nil {
+		query = orderResourcePool(sortBy, query)
 	}
 
 	if resourcePools, err := query.Paginate(ctx, after, first, before, last); err != nil {
@@ -819,7 +823,7 @@ func (r *queryResolver) QueryEmptyResourcePools(ctx context.Context, resourceTyp
 }
 
 // QueryResourcePools is the resolver for the QueryResourcePools field.
-func (r *queryResolver) QueryResourcePools(ctx context.Context, resourceTypeID *int, tags *model.TagOr, first *int, last *int, before *ent.Cursor, after *ent.Cursor, filterByResources map[string]interface{}) (*ent.ResourcePoolConnection, error) {
+func (r *queryResolver) QueryResourcePools(ctx context.Context, resourceTypeID *int, tags *model.TagOr, first *int, last *int, before *ent.Cursor, after *ent.Cursor, filterByResources map[string]interface{}, sortBy *model.SortResourcePoolsInput) (*ent.ResourcePoolConnection, error) {
 	client := r.ClientFrom(ctx)
 	query := client.ResourcePool.Query()
 
@@ -841,6 +845,10 @@ func (r *queryResolver) QueryResourcePools(ctx context.Context, resourceTypeID *
 	if tags != nil {
 		// TODO make sure all tags exist
 		query.Where(resourcePoolTagPredicate(tags))
+	}
+
+	if sortBy != nil {
+		query = orderResourcePool(sortBy, query)
 	}
 
 	if resourcePools, err := query.Paginate(ctx, after, first, before, last); err != nil {
@@ -923,7 +931,7 @@ func (r *queryResolver) QueryResourcePoolHierarchyPath(ctx context.Context, pool
 }
 
 // QueryRootResourcePools is the resolver for the QueryRootResourcePools field.
-func (r *queryResolver) QueryRootResourcePools(ctx context.Context, resourceTypeID *int, tags *model.TagOr, first *int, last *int, before *ent.Cursor, after *ent.Cursor, filterByResources map[string]interface{}) (*ent.ResourcePoolConnection, error) {
+func (r *queryResolver) QueryRootResourcePools(ctx context.Context, resourceTypeID *int, tags *model.TagOr, first *int, last *int, before *ent.Cursor, after *ent.Cursor, filterByResources map[string]interface{}, sortBy *model.SortResourcePoolsInput) (*ent.ResourcePoolConnection, error) {
 	client := r.ClientFrom(ctx)
 	query := client.ResourcePool.
 		Query().
@@ -949,6 +957,10 @@ func (r *queryResolver) QueryRootResourcePools(ctx context.Context, resourceType
 		query.Where(resourcePoolTagPredicate(tags))
 	}
 
+	if sortBy != nil {
+		query = orderResourcePool(sortBy, query)
+	}
+
 	if resourcePools, err := query.Paginate(ctx, after, first, before, last); err != nil {
 		log.Error(ctx, err, "Unable to retrieve root resource pools")
 		return nil, gqlerror.Errorf("Unable to query resource pools: %v", err)
@@ -958,7 +970,7 @@ func (r *queryResolver) QueryRootResourcePools(ctx context.Context, resourceType
 }
 
 // QueryLeafResourcePools is the resolver for the QueryLeafResourcePools field.
-func (r *queryResolver) QueryLeafResourcePools(ctx context.Context, resourceTypeID *int, tags *model.TagOr, first *int, last *int, before *ent.Cursor, after *ent.Cursor, filterByResources map[string]interface{}) (*ent.ResourcePoolConnection, error) {
+func (r *queryResolver) QueryLeafResourcePools(ctx context.Context, resourceTypeID *int, tags *model.TagOr, first *int, last *int, before *ent.Cursor, after *ent.Cursor, filterByResources map[string]interface{}, sortBy *model.SortResourcePoolsInput) (*ent.ResourcePoolConnection, error) {
 	client := r.ClientFrom(ctx)
 	query := client.ResourcePool.
 		Query().
@@ -983,6 +995,10 @@ func (r *queryResolver) QueryLeafResourcePools(ctx context.Context, resourceType
 	if tags != nil {
 		// TODO make sure all tags exist
 		query.Where(resourcePoolTagPredicate(tags))
+	}
+
+	if sortBy != nil {
+		query = orderResourcePool(sortBy, query)
 	}
 
 	if resourcePools, err := query.Paginate(ctx, after, first, before, last); err != nil {

--- a/graph/graphql/resolver/schema.resolvers.go
+++ b/graph/graphql/resolver/schema.resolvers.go
@@ -5,6 +5,7 @@ package resolver
 
 import (
 	"context"
+	"fmt"
 	"regexp"
 	"strconv"
 	"time"
@@ -1210,6 +1211,9 @@ type resourcePoolResolver struct{ *Resolver }
 //   - When renaming or deleting a resolver the old code will be put in here. You can safely delete
 //     it when you're done.
 //   - You have helper methods in this file. Move them out to keep these resolver files clean.
+func (r *resourcePoolResolver) PoolDealocationSafetyPeriod(ctx context.Context, obj *ent.ResourcePool) (int, error) {
+	panic(fmt.Errorf("not implemented: PoolDealocationSafetyPeriod - PoolDealocationSafetyPeriod"))
+}
 func (r *resourceResolver) NestedPool(ctx context.Context, obj *ent.Resource) (*ent.ResourcePool, error) {
 	if es, err := obj.Edges.NestedPoolOrErr(); !ent.IsNotLoaded(err) {
 		log.Error(ctx, err, "Unable to retrieve nested pool for resource with ID %d", obj.ID)

--- a/graph/graphql/resolver/utils.go
+++ b/graph/graphql/resolver/utils.go
@@ -342,3 +342,22 @@ func filterByJsonNumberVal(ctx context.Context, query *ent.PropertyTypeQuery, js
 		return nil, gqlerror.Errorf("Unable to filter by json number value: %v", err)
 	}
 }
+
+func orderResourcePool(input *model.SortResourcePoolsInput, query *ent.ResourcePoolQuery) *ent.ResourcePoolQuery {
+	var orderFunc ent.OrderFunc = nil
+	var sortKey = ""
+
+	if input.SortKey == model.SortResourcePoolsByDeallocationSafetyPeriod {
+		sortKey = "deallocation_safety_period"
+	} else {
+		sortKey = string(input.SortKey)
+	}
+
+	if input.Direction == model.SortDirectionAsc {
+		orderFunc = ent.Asc(sortKey)
+	} else {
+		orderFunc = ent.Desc(sortKey)
+	}
+
+	return query.Order(orderFunc)
+}

--- a/graph/graphql/resolver/utils.go
+++ b/graph/graphql/resolver/utils.go
@@ -343,14 +343,19 @@ func filterByJsonNumberVal(ctx context.Context, query *ent.PropertyTypeQuery, js
 	}
 }
 
-func orderResourcePool(input *model.SortResourcePoolsInput, query *ent.ResourcePoolQuery) *ent.ResourcePoolQuery {
+func orderResourcePool(input *model.SortResourcePoolsInput, query *ent.ResourcePoolQuery) (*ent.ResourcePoolQuery, error) {
 	var orderFunc ent.OrderFunc = nil
 	var sortKey = ""
 
-	if input.SortKey == model.SortResourcePoolsByDealocationSafetyPeriod {
-		sortKey = "dealocation_safety_period"
-	} else {
-		sortKey = string(input.SortKey)
+	switch input.SortKey {
+	case model.SortResourcePoolsByDealocationSafetyPeriod:
+		sortKey = resourcePool.FieldDealocationSafetyPeriod
+
+	case model.SortResourcePoolsByName:
+		sortKey = resourcePool.FieldName
+
+	default:
+		return nil, gqlerror.Errorf("Unable to order resource pool, unknown sort key: %v", input.SortKey)
 	}
 
 	if input.Direction == model.SortDirectionAsc {
@@ -359,5 +364,5 @@ func orderResourcePool(input *model.SortResourcePoolsInput, query *ent.ResourceP
 		orderFunc = ent.Desc(sortKey)
 	}
 
-	return query.Order(orderFunc)
+	return query.Order(orderFunc), nil
 }

--- a/graph/graphql/resolver/utils.go
+++ b/graph/graphql/resolver/utils.go
@@ -347,8 +347,8 @@ func orderResourcePool(input *model.SortResourcePoolsInput, query *ent.ResourceP
 	var orderFunc ent.OrderFunc = nil
 	var sortKey = ""
 
-	if input.SortKey == model.SortResourcePoolsByDeallocationSafetyPeriod {
-		sortKey = "deallocation_safety_period"
+	if input.SortKey == model.SortResourcePoolsByDealocationSafetyPeriod {
+		sortKey = "dealocation_safety_period"
 	} else {
 		sortKey = string(input.SortKey)
 	}

--- a/graph/graphql/schema/schema.graphql
+++ b/graph/graphql/schema/schema.graphql
@@ -353,6 +353,21 @@ type PoolCapacityPayload {
     utilizedCapacity: String!
 }
 
+enum SortResourcePoolsBy {
+    name
+    deallocationSafetyPeriod
+}
+
+enum SortDirection {
+    asc
+    desc
+}
+
+input SortResourcePoolsInput {
+    sortKey: SortResourcePoolsBy!
+    direction: SortDirection!
+}
+
 type Query {
     # Deprecated, use capacity object inside the Resource pool
     QueryPoolCapacity(poolId: ID!): PoolCapacityPayload!
@@ -368,13 +383,13 @@ type Query {
 
     QueryResourcePool(poolId: ID!): ResourcePool!
 
-    QueryEmptyResourcePools(resourceTypeId: ID, first: Int, last: Int, before: Cursor, after: Cursor): ResourcePoolConnection!
-    QueryResourcePools(resourceTypeId: ID, tags: TagOr, first: Int, last: Int, before: Cursor, after: Cursor, filterByResources: Map): ResourcePoolConnection!
+    QueryEmptyResourcePools(resourceTypeId: ID, first: Int, last: Int, before: Cursor, after: Cursor, sortBy: SortResourcePoolsInput): ResourcePoolConnection!
+    QueryResourcePools(resourceTypeId: ID, tags: TagOr, first: Int, last: Int, before: Cursor, after: Cursor, filterByResources: Map, sortBy: SortResourcePoolsInput): ResourcePoolConnection!
     QueryRecentlyActiveResources(fromDatetime: String!, toDatetime: String,
         first: Int, last: Int, before: String, after: String): ResourceConnection!
     QueryResourcePoolHierarchyPath(poolId: ID!): [ResourcePool!]!
-    QueryRootResourcePools(resourceTypeId: ID, tags: TagOr, first: Int, last: Int, before: Cursor, after: Cursor, filterByResources: Map): ResourcePoolConnection!
-    QueryLeafResourcePools(resourceTypeId: ID, tags: TagOr, first: Int, last: Int, before: Cursor, after: Cursor, filterByResources: Map): ResourcePoolConnection!
+    QueryRootResourcePools(resourceTypeId: ID, tags: TagOr, first: Int, last: Int, before: Cursor, after: Cursor, filterByResources: Map, sortBy: SortResourcePoolsInput): ResourcePoolConnection!
+    QueryLeafResourcePools(resourceTypeId: ID, tags: TagOr, first: Int, last: Int, before: Cursor, after: Cursor, filterByResources: Map, sortBy: SortResourcePoolsInput): ResourcePoolConnection!
     SearchPoolsByTags(tags: TagOr, first: Int, last: Int, before: Cursor, after: Cursor): ResourcePoolConnection!
 
     QueryTags: [Tag!]!

--- a/graph/graphql/schema/schema.graphql
+++ b/graph/graphql/schema/schema.graphql
@@ -94,6 +94,7 @@ type ResourcePool implements Node
     PoolType: PoolType!
     ResourceType: ResourceType!
     Resources: [Resource!]!
+    DealocationSafetyPeriod: Int!
     Tags: [Tag!]!
     allocatedResources(first: Int, last: Int, before: String, after: String): ResourceConnection
     id: ID!
@@ -355,7 +356,7 @@ type PoolCapacityPayload {
 
 enum SortResourcePoolsBy {
     name
-    deallocationSafetyPeriod
+    dealocationSafetyPeriod
 }
 
 enum SortDirection {


### PR DESCRIPTION
What has been changed:
- add sorting possibility for resource pools (sort by name or dealocation safety period)
- added dealocation safety property to graphql scheme of resource pool
- added 4 tests for sorting of resource pools
- updated graphql queries to be able to have an access to Name and DealocationSafetyPeriod properties of resource pool
- created new function for graphql mutation to be able to create resource pool with specific name
- updated function for creating new ipv4 prefix root pool, to be able to define specific value for dealocation safety period
- controlling validity of sort key 

ticket related to this PR - https://frinxhelpdesk.atlassian.net/browse/FI-1692