### PR TITLE
add go to alloc strategy enum

### DIFF
--- a/api-tests/src/graphql-queries.js
+++ b/api-tests/src/graphql-queries.js
@@ -64,6 +64,22 @@ export async function findAllocationStrategyId(name){
     .catch(error => console.log(error));
 }
 
+export async function getAllocationStrategies(){
+    return client.query({
+        query: gql`
+            query { QueryAllocationStrategies {
+                id
+                Name
+                Description
+                Lang
+            }
+            }
+        `,
+    })
+    .then(result => result.data.QueryAllocationStrategies)
+    .catch(error => console.log(error));
+}
+
 export async function getCapacityForPool(poolId){
     return client.query({
         query: gql`

--- a/api-tests/src/tests/strategy.test.js
+++ b/api-tests/src/tests/strategy.test.js
@@ -3,7 +3,7 @@ import {
     testStrategy,
     createAllocationStrategy,
     findAllocationStrategyId,
-    createResourceType, findResourceTypeId, deleteResourceType, getRequiredPoolProperties
+    createResourceType, findResourceTypeId, deleteResourceType, getRequiredPoolProperties, getAllocationStrategies
 } from '../graphql-queries.js';
 import {cleanup, getUniqueName} from '../test-helpers.js';
 import tap from 'tap';
@@ -255,5 +255,14 @@ test('vlan strategy', async (t) => {
     t.equal(allocated.stdout.vlan, 0);
 
     await cleanup()
+    t.end();
+});
+
+test('query all allocation strategies', async (t) => {
+    let strategies = await getAllocationStrategies();
+
+    t.ok(strategies);
+
+    await cleanup();
     t.end();
 });

--- a/graph/graphql/generated/generated.go
+++ b/graph/graphql/generated/generated.go
@@ -1552,6 +1552,7 @@ enum AllocationStrategyLang
 {
     js
     py
+    go
 }
 
 """

--- a/graph/graphql/schema/schema.graphql
+++ b/graph/graphql/schema/schema.graphql
@@ -150,6 +150,7 @@ enum AllocationStrategyLang
 {
     js
     py
+    go
 }
 
 """


### PR DESCRIPTION
- added go case to allocation strategy enum in schema.graphql file
- this change was needed because when querying allocation strategies we get error that if strategy is written in go then we cannot load them since it is type error

`Value \"go\" does not exist in \"AllocationStrategyLang\" enum.`